### PR TITLE
std::get_time and strptime for the truly unfortunate. (Closes #9)

### DIFF
--- a/inst/include/get_time.h
+++ b/inst/include/get_time.h
@@ -1,0 +1,881 @@
+// =============================================================================
+// The code in this file has been adapted from code in the locale header from
+// the LLVM libc++ project and is licensed as follows.
+//
+// =============================================================================
+// libc++ License
+// =============================================================================
+// 
+// The libc++ library is dual licensed under both the University of Illinois
+// "BSD-Like" license and the MIT license.  As a user of this code you may
+// choose to use it under either license.  As a contributor, you agree to allow
+// your code to be used under both.
+// 
+// Full text of the relevant licenses is included below.
+// 
+// =============================================================================
+// 
+// University of Illinois/NCSA
+// Open Source License
+// 
+// Copyright (c) 2009-2016 by the contributors listed in CREDITS.TXT
+// 
+// All rights reserved.
+// 
+// Developed by:
+// 
+//     LLVM Team
+// 
+//     University of Illinois at Urbana-Champaign
+// 
+//     http://llvm.org
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// with the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimers.
+// 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimers in the
+//       documentation and/or other materials provided with the distribution.
+// 
+//     * Neither the names of the LLVM Team, University of Illinois at
+//       Urbana-Champaign, nor the names of its contributors may be used to
+//       endorse or promote products derived from this Software without specific
+//       prior written permission.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+// THE SOFTWARE.
+// 
+// =============================================================================
+// 
+// Copyright (c) 2009-2014 by the contributors listed in CREDITS.TXT
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef RCPP_CCTZ_GET_TIME
+#define RCPP_CCTZ_GET_TIME
+
+#include <iostream>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+
+namespace std_backport
+{
+template <class InputIterator, class ForwardIterator, class Ctype>
+ForwardIterator
+scan_keyword(InputIterator& b, InputIterator e,
+               ForwardIterator kb, ForwardIterator ke,
+               const Ctype& ct, std::ios_base::iostate& err,
+               bool case_sensitive = true)
+{
+    typedef typename std::iterator_traits<InputIterator>::value_type CharT;
+    size_t nkw = static_cast<size_t>(distance(kb, ke));
+    const unsigned char doesnt_match = '\0';
+    const unsigned char might_match = '\1';
+    const unsigned char does_match = '\2';
+    unsigned char statbuf[100];
+    unsigned char* status = statbuf;
+    unsigned char* stat_hold = NULL;
+    
+    if (nkw > sizeof(statbuf))
+    {
+        status = (unsigned char*)malloc(nkw);
+        if (status == 0)
+        {
+            free(stat_hold);
+            throw std::bad_alloc();
+        }
+        stat_hold =status;
+    }
+    size_t n_might_match = nkw;  // At this point, any keyword might match
+    size_t n_does_match = 0;       // but none of them definitely do
+    // Initialize all statuses to might_match, except for "" keywords are does_match
+    unsigned char* st = status;
+    for (ForwardIterator ky = kb; ky != ke; ++ky, (void) ++st)
+    {
+        if (!ky->empty())
+            *st = might_match;
+        else
+        {
+            *st = does_match;
+            --n_might_match;
+            ++n_does_match;
+        }
+    }
+    // While there might be a match, test keywords against the next CharT
+    for (size_t indx = 0; b != e && n_might_match > 0; ++indx)
+    {
+        // Peek at the next CharT but don't consume it
+        CharT c = *b;
+        if (!case_sensitive)
+            c = ct.toupper(c);
+        bool consume = false;
+        // For each keyword which might match, see if the indx character is c
+        // If a match if found, consume c
+        // If a match is found, and that is the last character in the keyword,
+        //    then that keyword matches.
+        // If the keyword doesn't match this character, then change the keyword
+        //    to doesn't match
+        st = status;
+        for (ForwardIterator ky = kb; ky != ke; ++ky, (void) ++st)
+        {
+            if (*st == might_match)
+            {
+                CharT kc = (*ky)[indx];
+                if (!case_sensitive)
+                    kc = ct.toupper(kc);
+                if (c == kc)
+                {
+                    consume = true;
+                    if (ky->size() == indx+1)
+                    {
+                        *st = does_match;
+                        --n_might_match;
+                        ++n_does_match;
+                    }
+                }
+                else
+                {
+                    *st = doesnt_match;
+                    --n_might_match;
+                }
+            }
+        }
+        // consume if we matched a character
+        if (consume)
+        {
+            ++b;
+            // If we consumed a character and there might be a matched keyword that
+            //   was marked matched on a previous iteration, then such keywords
+            //   which are now marked as not matching.
+            if (n_might_match + n_does_match > 1)
+            {
+                st = status;
+                for (ForwardIterator ky = kb; ky != ke; ++ky, (void) ++st)
+                {
+                    if (*st == does_match && ky->size() != indx+1)
+                    {
+                        *st = doesnt_match;
+                        --n_does_match;
+                    }
+                }
+            }
+        }
+    }
+    // We've exited the loop because we hit eof and/or we have no more "might matches".
+    if (b == e)
+        err |= std::ios_base::eofbit;
+    // Return the first matching result
+    for (st = status; kb != ke; ++kb, (void) ++st)
+        if (*st == does_match)
+            break;
+    if (kb == ke)
+    {
+        err |= std::ios_base::failbit;
+    }
+    
+    free (stat_hold);
+    return kb;
+}
+
+template <class CharT, class InputIterator>
+int
+get_up_to_n_digits(InputIterator& b, InputIterator e,
+                     std::ios_base::iostate& err, const std::ctype<CharT>& ct, int n)
+{
+    // Precondition:  n >= 1
+    if (b == e)
+    {
+        err |= std::ios_base::eofbit | std::ios_base::failbit;
+        return 0;
+    }
+    // get first digit
+    CharT c = *b;
+    if (!ct.is(std::ctype_base::digit, c))
+    {
+        err |= std::ios_base::failbit;
+        return 0;
+    }
+    int r = ct.narrow(c, 0) - '0';
+    for (++b, (void) --n; b != e && n > 0; ++b, (void) --n)
+    {
+        // get next digit
+        c = *b;
+        if (!ct.is(std::ctype_base::digit, c))
+            return r;
+        r = r * 10 + ct.narrow(c, 0) - '0';
+    }
+    if (b == e)
+        err |= std::ios_base::eofbit;
+    return r;
+}
+
+template <class CharT>
+class time_get_c_storage
+{
+protected:
+    typedef std::basic_string<CharT> string_type;
+
+    virtual const string_type* am_pm() const;
+    virtual const string_type& c() const;
+    virtual const string_type& r() const;
+    virtual const string_type& x() const;
+    virtual const string_type& X() const;
+
+    ~time_get_c_storage() {}
+};
+
+static
+std::string*
+init_am_pm()
+{
+    static std::string am_pm[2];
+    am_pm[0]  = "AM";
+    am_pm[1]  = "PM";
+    return am_pm;
+}
+
+static
+std::wstring*
+init_wam_pm()
+{
+    static std::wstring am_pm[2];
+    am_pm[0]  = L"AM";
+    am_pm[1]  = L"PM";
+    return am_pm;
+}
+
+template <>
+const std::string*
+time_get_c_storage<char>::am_pm() const
+{
+    static const std::string* am_pm = init_am_pm();
+    return am_pm;
+}
+
+template <>
+const std::wstring*
+time_get_c_storage<wchar_t>::am_pm() const
+{
+    static const std::wstring* am_pm = init_wam_pm();
+    return am_pm;
+}
+
+template <>
+const std::string&
+time_get_c_storage<char>::x() const
+{
+    static std::string s("%m/%d/%y");
+    return s;
+}
+
+template <>
+const std::wstring&
+time_get_c_storage<wchar_t>::x() const
+{
+    static std::wstring s(L"%m/%d/%y");
+    return s;
+}
+
+template <>
+const std::string&
+time_get_c_storage<char>::X() const
+{
+    static std::string s("%H:%M:%S");
+    return s;
+}
+
+template <>
+const std::wstring&
+time_get_c_storage<wchar_t>::X() const
+{
+    static std::wstring s(L"%H:%M:%S");
+    return s;
+}
+
+template <>
+const std::string&
+time_get_c_storage<char>::c() const
+{
+    static std::string s("%a %b %d %H:%M:%S %Y");
+    return s;
+}
+
+template <>
+const std::wstring&
+time_get_c_storage<wchar_t>::c() const
+{
+    static std::wstring s(L"%a %b %d %H:%M:%S %Y");
+    return s;
+}
+
+template <>
+const std::string&
+time_get_c_storage<char>::r() const
+{
+    static std::string s("%I:%M:%S %p");
+    return s;
+}
+
+template <>
+const std::wstring&
+time_get_c_storage<wchar_t>::r() const
+{
+    static std::wstring s(L"%I:%M:%S %p");
+    return s;
+}
+
+template <class CharT, class InputIterator>
+class my_time_get : public std::time_get<CharT, InputIterator>,
+    public time_get_c_storage<CharT>
+{
+public:
+    typedef CharT                  char_type;
+    typedef InputIterator          iter_type;
+    typedef std::time_base::dateorder    dateorder;
+    typedef std::basic_string<char_type> string_type;
+    
+    my_time_get() {}
+    my_time_get(const std::time_get<CharT, InputIterator>& tg)
+    {
+    }
+    
+    iter_type get(iter_type b, iter_type e, std::ios_base& iob,
+                  std::ios_base::iostate& err, tm *tm,
+                  char fmt, char mod = 0) const
+    {
+        return do_get(b, e, iob, err, tm, fmt, mod);
+    }
+
+    iter_type get(iter_type b, iter_type e, std::ios_base& iob,
+                  std::ios_base::iostate& err, tm* tm,
+                  const char_type* fmtb, const char_type* fmte) const;
+    
+private:
+    InputIterator do_get(iter_type b, iter_type e,
+                          std::ios_base& iob,
+                          std::ios_base::iostate& err, tm* tm,
+                          char fmt, char) const;
+    
+    void get_white_space(iter_type& b, iter_type e,
+                           std::ios_base::iostate& err, const std::ctype<char_type>& ct) const;
+    void get_percent(iter_type& b, iter_type e, std::ios_base::iostate& err,
+                       const std::ctype<char_type>& ct) const;
+    void get_day(int& d,
+                   iter_type& b, iter_type e,
+                   std::ios_base::iostate& err,
+                   const std::ctype<char_type>& ct) const;
+    void get_month(int& m,
+                     iter_type& b, iter_type e,
+                     std::ios_base::iostate& err,
+                     const std::ctype<char_type>& ct) const;
+    void get_year(int& y,
+                   iter_type& b, iter_type e,
+                   std::ios_base::iostate& err,
+                   const std::ctype<char_type>& ct) const;
+    void get_year4(int& y,
+                    iter_type& b, iter_type e,
+                    std::ios_base::iostate& err,
+                    const std::ctype<char_type>& ct) const;
+    void get_hour(int& d,
+                    iter_type& b, iter_type e,
+                    std::ios_base::iostate& err,
+                    const std::ctype<char_type>& ct) const;
+    void get_12_hour(int& h,
+                       iter_type& b, iter_type e,
+                       std::ios_base::iostate& err,
+                       const std::ctype<char_type>& ct) const;
+    void get_am_pm(int& h,
+                     iter_type& b, iter_type e,
+                     std::ios_base::iostate& err,
+                     const std::ctype<char_type>& ct) const;
+    void get_minute(int& m,
+                      iter_type& b, iter_type e,
+                      std::ios_base::iostate& err,
+                      const std::ctype<char_type>& ct) const;
+    void get_second(int& s,
+                      iter_type& b, iter_type e,
+                      std::ios_base::iostate& err,
+                      const std::ctype<char_type>& ct) const;
+    void get_weekday(int& w,
+                       iter_type& b, iter_type e,
+                       std::ios_base::iostate& err,
+                       const std::ctype<char_type>& ct) const;
+    void get_day_year_num(int& w,
+                            iter_type& b, iter_type e,
+                            std::ios_base::iostate& err,
+                            const std::ctype<char_type>& ct) const;
+
+};
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_day(int& d,
+                                            iter_type& b, iter_type e,
+                                            std::ios_base::iostate& err,
+                                            const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 2);
+    if (!(err & std::ios_base::failbit) && 1 <= t && t <= 31)
+        d = t;
+    else
+    {
+        err |= std::ios_base::failbit;
+    }
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_month(int& m,
+                                              iter_type& b, iter_type e,
+                                              std::ios_base::iostate& err,
+                                              const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 2) - 1;
+    if (!(err & std::ios_base::failbit) && t <= 11)
+        m = t;
+    else
+    {
+        err |= std::ios_base::failbit;
+    }
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_year(int& y,
+                                             iter_type& b, iter_type e,
+                                             std::ios_base::iostate& err,
+                                             const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 4);
+    if (!(err & std::ios_base::failbit))
+    {
+        if (t < 69)
+            t += 2000;
+        else if (69 <= t && t <= 99)
+            t += 1900;
+        y = t - 1900;
+    }
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_year4(int& y,
+                                              iter_type& b, iter_type e,
+                                              std::ios_base::iostate& err,
+                                              const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 4);
+    if (!(err & std::ios_base::failbit))
+        y = t - 1900;
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_hour(int& h,
+                                             iter_type& b, iter_type e,
+                                             std::ios_base::iostate& err,
+                                             const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 2);
+    if (!(err & std::ios_base::failbit) && t <= 23)
+        h = t;
+    else
+    {
+        err |= std::ios_base::failbit;
+    }
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_12_hour(int& h,
+                                                iter_type& b, iter_type e,
+                                                std::ios_base::iostate& err,
+                                                const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 2);
+    if (!(err & std::ios_base::failbit) && 1 <= t && t <= 12)
+        h = t;
+    else
+    {
+        err |= std::ios_base::failbit;
+    }
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_minute(int& m,
+                                               iter_type& b, iter_type e,
+                                               std::ios_base::iostate& err,
+                                               const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 2);
+    if (!(err & std::ios_base::failbit) && t <= 59)
+        m = t;
+    else
+    {
+        err |= std::ios_base::failbit;
+    }
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_second(int& s,
+                                               iter_type& b, iter_type e,
+                                               std::ios_base::iostate& err,
+                                               const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 2);
+    if (!(err & std::ios_base::failbit) && t <= 60)
+        s = t;
+    else
+    {
+        err |= std::ios_base::failbit;
+    }
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_weekday(int& w,
+                                                iter_type& b, iter_type e,
+                                                std::ios_base::iostate& err,
+                                                const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 1);
+    if (!(err & std::ios_base::failbit) && t <= 6)
+        w = t;
+    else
+        err |= std::ios_base::failbit;
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_day_year_num(int& d,
+                                                     iter_type& b, iter_type e,
+                                                     std::ios_base::iostate& err,
+                                                     const std::ctype<char_type>& ct) const
+{
+    int t = get_up_to_n_digits(b, e, err, ct, 3);
+    if (!(err & std::ios_base::failbit) && t <= 365)
+        d = t;
+    else
+    {
+        err |= std::ios_base::failbit;
+    }
+}
+
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_white_space(iter_type& b, iter_type e,
+                                                    std::ios_base::iostate& err,
+                                                    const std::ctype<char_type>& ct) const
+{
+    for (; b != e && ct.is(std::ctype_base::space, *b); ++b)
+        ;
+    if (b == e)
+        err |= std::ios_base::eofbit;
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_am_pm(int& h,
+                                              iter_type& b, iter_type e,
+                                              std::ios_base::iostate& err,
+                                              const std::ctype<char_type>& ct) const
+{
+    const string_type* ap = this->am_pm();
+    if (ap[0].size() + ap[1].size() == 0)
+    {
+        abort();
+        err |= std::ios_base::failbit;
+        return;
+    }
+    std::ptrdiff_t i = scan_keyword(b, e, ap, ap+2, ct, err, false) - ap;
+    if (i == 0 && h == 12)
+        h = 0;
+    else if (i == 1 && h < 12)
+        h += 12;
+}
+
+template <class CharT, class InputIterator>
+void
+my_time_get<CharT, InputIterator>::get_percent(iter_type& b, iter_type e,
+                                                std::ios_base::iostate& err,
+                                                const std::ctype<char_type>& ct) const
+{
+    if (b == e)
+    {
+        err |= std::ios_base::eofbit | std::ios_base::failbit;
+        return;
+    }
+    if (ct.narrow(*b, 0) != '%')
+    {
+        err |= std::ios_base::failbit;
+    }
+    else if(++b == e)
+    {
+        err |= std::ios_base::eofbit;
+    }
+}
+
+template <class CharT, class InputIterator>
+InputIterator
+my_time_get<CharT, InputIterator>::get(iter_type b, iter_type e,
+                                      std::ios_base& iob,
+                                      std::ios_base::iostate& err, tm* tm,
+                                      const char_type* fmtb, const char_type* fmte) const
+{
+    const std::ctype<char_type>& ct = std::use_facet<std::ctype<char_type> >(iob.getloc());
+    err = std::ios_base::goodbit;
+    while (fmtb != fmte && err == std::ios_base::goodbit)
+    {
+        if (b == e)
+        {
+            err = std::ios_base::failbit;
+            break;
+        }
+        if (ct.narrow(*fmtb, 0) == '%')
+        {
+            if (++fmtb == fmte)
+            {
+                err = std::ios_base::failbit;
+                break;
+            }
+            char cmd = ct.narrow(*fmtb, 0);
+            char opt = '\0';
+            if (cmd == 'E' || cmd == '0')
+            {
+                if (++fmtb == fmte)
+                {
+                    err = std::ios_base::failbit;
+                    break;
+                }
+                opt = cmd;
+                cmd = ct.narrow(*fmtb, 0);
+            }
+            b = do_get(b, e, iob, err, tm, cmd, opt);
+            ++fmtb;
+        }
+        else if (ct.is(std::ctype_base::space, *fmtb))
+        {
+            for (++fmtb; fmtb != fmte && ct.is(std::ctype_base::space, *fmtb); ++fmtb)
+                ;
+            for (        ;    b != e    && ct.is(std::ctype_base::space, *b);    ++b)
+                ;
+        }
+        else if (ct.toupper(*b) == ct.toupper(*fmtb))
+        {
+            ++b;
+            ++fmtb;
+        }
+        else
+        {
+            err = std::ios_base::failbit;
+        }
+    }
+    if (b == e)
+        err |= std::ios_base::eofbit;
+    return b;
+}
+
+template <class CharT, class InputIterator>
+InputIterator
+my_time_get<CharT, InputIterator>::do_get(iter_type b, iter_type e,
+                                         std::ios_base& iob,
+                                         std::ios_base::iostate& err, tm* tm,
+                                         char fmt, char) const
+{
+    err = std::ios_base::goodbit;
+    const std::ctype<char_type>& ct = std::use_facet<std::ctype<char_type> >(iob.getloc());
+    switch (fmt)
+    {
+    case 'a':
+    case 'A':
+        b = std::time_get<CharT, InputIterator>::get_weekday(b, e, iob, err, tm);
+        break;
+    case 'b':
+    case 'B':
+    case 'h':
+        b = std::time_get<CharT, InputIterator>::get_monthname(b, e, iob, err, tm);
+        break;
+    case 'c':
+        {
+        const string_type& fm = this->c();
+        b = get(b, e, iob, err, tm, fm.data(), fm.data() + fm.size());
+        }
+        break;
+    case 'd':
+    case 'e':
+        get_day(tm->tm_mday, b, e, err, ct);
+        break;
+    case 'D':
+        {
+        const char_type fm[] = {'%', 'm', '/', '%', 'd', '/', '%', 'y'};
+        b = get(b, e, iob, err, tm, fm, fm + sizeof(fm)/sizeof(fm[0]));
+        }
+        break;
+    case 'F':
+        {
+        const char_type fm[] = {'%', 'Y', '-', '%', 'm', '-', '%', 'd'};
+        b = get(b, e, iob, err, tm, fm, fm + sizeof(fm)/sizeof(fm[0]));
+        }
+        break;
+    case 'H':
+        get_hour(tm->tm_hour, b, e, err, ct);
+        break;
+    case 'I':
+        get_12_hour(tm->tm_hour, b, e, err, ct);
+        break;
+    case 'j':
+        get_day_year_num(tm->tm_yday, b, e, err, ct);
+        break;
+    case 'm':
+        get_month(tm->tm_mon, b, e, err, ct);
+        break;
+    case 'M':
+        get_minute(tm->tm_min, b, e, err, ct);
+        break;
+    case 'n':
+    case 't':
+        get_white_space(b, e, err, ct);
+        break;
+    case 'p':
+        get_am_pm(tm->tm_hour, b, e, err, ct);
+        if (err & std::ios_base::failbit) {
+            abort();              
+        }
+        break;
+    case 'r':
+        {
+        const char_type fm[] = {'%', 'I', ':', '%', 'M', ':', '%', 'S', ' ', '%', 'p'};
+        b = get(b, e, iob, err, tm, fm, fm + sizeof(fm)/sizeof(fm[0]));
+        }
+        break;
+    case 'R':
+        {
+        const char_type fm[] = {'%', 'H', ':', '%', 'M'};
+        b = get(b, e, iob, err, tm, fm, fm + sizeof(fm)/sizeof(fm[0]));
+        }
+        break;
+    case 'S':
+        get_second(tm->tm_sec, b, e, err, ct);
+        break;
+    case 'T':
+        {
+        const char_type fm[] = {'%', 'H', ':', '%', 'M', ':', '%', 'S'};
+        b = get(b, e, iob, err, tm, fm, fm + sizeof(fm)/sizeof(fm[0]));
+        }
+        break;
+    case 'w':
+        get_weekday(tm->tm_wday, b, e, err, ct);
+        break;
+    case 'x':
+        return my_time_get< char_type, iter_type >::do_get_date(b, e, iob, err, tm);
+    case 'X':
+        {
+        const string_type& fm = this->X();
+        b = get(b, e, iob, err, tm, fm.data(), fm.data() + fm.size());
+        }
+        break;
+    case 'y':
+        get_year(tm->tm_year, b, e, err, ct);
+        break;
+    case 'Y':
+        get_year4(tm->tm_year, b, e, err, ct);
+        break;
+    case '%':
+        get_percent(b, e, err, ct);
+        break;
+    default:
+        err |= std::ios_base::failbit;
+    }
+    return b;
+}
+        
+        
+        
+        
+template <class CharT> class iom_t9;
+
+template <class CharT, class Traits>
+std::basic_istream<CharT, Traits>&
+operator>>(std::basic_istream<CharT, Traits>& is, const iom_t9<CharT>& x);
+
+template <class CharT>
+class iom_t9
+{
+    tm* tm_;
+    const CharT* fmt_;
+public:
+    iom_t9(tm* tm, const CharT* fmt)
+        : tm_(tm), fmt_(fmt) {}
+
+    template <class _Cp, class Traits>
+    friend
+    std::basic_istream<_Cp, Traits>&
+    operator>>(std::basic_istream<_Cp, Traits>& is, const iom_t9<_Cp>& x);
+};
+
+
+template <class CharT, class Traits>
+std::basic_istream<CharT, Traits>&
+operator>>(std::basic_istream<CharT, Traits>& is, const iom_t9<CharT>& x)
+{
+        typename std::basic_istream<CharT, Traits>::sentry s(is);
+        if (s)
+        {
+            typedef std::istreambuf_iterator<CharT, Traits> _Ip;
+            typedef my_time_get<CharT, _Ip> _Fp;
+            std::ios_base::iostate err = std::ios_base::goodbit;
+            const _Fp& tf = std::use_facet<std::time_get<CharT, _Ip> >(is.getloc());
+            tf.get(_Ip(is), _Ip(), is, err, x.tm_,
+                     x.fmt_, x.fmt_ + Traits::length(x.fmt_));
+            is.setstate(err);
+        }
+    return is;
+}
+
+
+template <class CharT>
+inline
+iom_t9<CharT>
+get_time(tm* tm, const CharT* fmt)
+{
+    return iom_t9<CharT>(tm, fmt);
+}
+
+}
+
+#endif

--- a/inst/include/get_time.h
+++ b/inst/include/get_time.h
@@ -421,7 +421,7 @@ time_get_c_storage<wchar_t>::r() const
 }
 
 template <class CharT, class InputIterator>
-class my_time_get : public time_get_c_storage<CharT>
+class time_parser : public time_get_c_storage<CharT>
 {
 private:
     const std::time_get<CharT, InputIterator> &tg_;
@@ -432,7 +432,7 @@ public:
     typedef std::time_base::dateorder    dateorder;
     typedef std::basic_string<char_type> string_type;
     
-    my_time_get(const std::locale& loc) : time_get_c_storage<CharT>(loc),
+    time_parser(const std::locale& loc) : time_get_c_storage<CharT>(loc),
         tg_(std::use_facet< std::time_get<CharT, InputIterator> >(loc))
     {
     }
@@ -507,7 +507,7 @@ private:
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_day(int& d,
+time_parser<CharT, InputIterator>::get_day(int& d,
                                             iter_type& b, iter_type e,
                                             std::ios_base::iostate& err,
                                             const std::ctype<char_type>& ct) const
@@ -523,7 +523,7 @@ my_time_get<CharT, InputIterator>::get_day(int& d,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_month(int& m,
+time_parser<CharT, InputIterator>::get_month(int& m,
                                               iter_type& b, iter_type e,
                                               std::ios_base::iostate& err,
                                               const std::ctype<char_type>& ct) const
@@ -539,7 +539,7 @@ my_time_get<CharT, InputIterator>::get_month(int& m,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_year(int& y,
+time_parser<CharT, InputIterator>::get_year(int& y,
                                              iter_type& b, iter_type e,
                                              std::ios_base::iostate& err,
                                              const std::ctype<char_type>& ct) const
@@ -557,7 +557,7 @@ my_time_get<CharT, InputIterator>::get_year(int& y,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_year4(int& y,
+time_parser<CharT, InputIterator>::get_year4(int& y,
                                               iter_type& b, iter_type e,
                                               std::ios_base::iostate& err,
                                               const std::ctype<char_type>& ct) const
@@ -569,7 +569,7 @@ my_time_get<CharT, InputIterator>::get_year4(int& y,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_hour(int& h,
+time_parser<CharT, InputIterator>::get_hour(int& h,
                                              iter_type& b, iter_type e,
                                              std::ios_base::iostate& err,
                                              const std::ctype<char_type>& ct) const
@@ -585,7 +585,7 @@ my_time_get<CharT, InputIterator>::get_hour(int& h,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_12_hour(int& h,
+time_parser<CharT, InputIterator>::get_12_hour(int& h,
                                                 iter_type& b, iter_type e,
                                                 std::ios_base::iostate& err,
                                                 const std::ctype<char_type>& ct) const
@@ -601,7 +601,7 @@ my_time_get<CharT, InputIterator>::get_12_hour(int& h,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_minute(int& m,
+time_parser<CharT, InputIterator>::get_minute(int& m,
                                                iter_type& b, iter_type e,
                                                std::ios_base::iostate& err,
                                                const std::ctype<char_type>& ct) const
@@ -617,7 +617,7 @@ my_time_get<CharT, InputIterator>::get_minute(int& m,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_second(int& s,
+time_parser<CharT, InputIterator>::get_second(int& s,
                                                iter_type& b, iter_type e,
                                                std::ios_base::iostate& err,
                                                const std::ctype<char_type>& ct) const
@@ -633,7 +633,7 @@ my_time_get<CharT, InputIterator>::get_second(int& s,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_weekday(int& w,
+time_parser<CharT, InputIterator>::get_weekday(int& w,
                                                 iter_type& b, iter_type e,
                                                 std::ios_base::iostate& err,
                                                 const std::ctype<char_type>& ct) const
@@ -647,7 +647,7 @@ my_time_get<CharT, InputIterator>::get_weekday(int& w,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_day_year_num(int& d,
+time_parser<CharT, InputIterator>::get_day_year_num(int& d,
                                                      iter_type& b, iter_type e,
                                                      std::ios_base::iostate& err,
                                                      const std::ctype<char_type>& ct) const
@@ -664,7 +664,7 @@ my_time_get<CharT, InputIterator>::get_day_year_num(int& d,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_white_space(iter_type& b, iter_type e,
+time_parser<CharT, InputIterator>::get_white_space(iter_type& b, iter_type e,
                                                     std::ios_base::iostate& err,
                                                     const std::ctype<char_type>& ct) const
 {
@@ -676,7 +676,7 @@ my_time_get<CharT, InputIterator>::get_white_space(iter_type& b, iter_type e,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_am_pm(int& h,
+time_parser<CharT, InputIterator>::get_am_pm(int& h,
                                               iter_type& b, iter_type e,
                                               std::ios_base::iostate& err,
                                               const std::ctype<char_type>& ct) const
@@ -696,7 +696,7 @@ my_time_get<CharT, InputIterator>::get_am_pm(int& h,
 
 template <class CharT, class InputIterator>
 void
-my_time_get<CharT, InputIterator>::get_percent(iter_type& b, iter_type e,
+time_parser<CharT, InputIterator>::get_percent(iter_type& b, iter_type e,
                                                 std::ios_base::iostate& err,
                                                 const std::ctype<char_type>& ct) const
 {
@@ -717,7 +717,7 @@ my_time_get<CharT, InputIterator>::get_percent(iter_type& b, iter_type e,
 
 template <class CharT, class InputIterator>
 InputIterator
-my_time_get<CharT, InputIterator>::get(iter_type b, iter_type e,
+time_parser<CharT, InputIterator>::get(iter_type b, iter_type e,
                                       std::ios_base& iob,
                                       std::ios_base::iostate& err, tm* tm,
                                       const char_type* fmtb, const char_type* fmte) const
@@ -778,7 +778,7 @@ my_time_get<CharT, InputIterator>::get(iter_type b, iter_type e,
 
 template <class CharT, class InputIterator>
 InputIterator
-my_time_get<CharT, InputIterator>::do_get(iter_type b, iter_type e,
+time_parser<CharT, InputIterator>::do_get(iter_type b, iter_type e,
                                          std::ios_base& iob,
                                          std::ios_base::iostate& err, tm* tm,
                                          char fmt, char) const
@@ -921,7 +921,7 @@ operator>>(std::basic_istream<CharT, Traits>& is, const iom_t9<CharT>& x)
         if (s)
         {
             typedef std::istreambuf_iterator<CharT, Traits> _Ip;
-            typedef my_time_get<CharT, _Ip> _Fp;
+            typedef time_parser<CharT, _Ip> _Fp;
             std::ios_base::iostate err = std::ios_base::goodbit;
             const _Fp tf(is.getloc());
             tf.get(_Ip(is), _Ip(), is, err, x.tm_,

--- a/src/examples.cpp
+++ b/src/examples.cpp
@@ -74,7 +74,7 @@ int example2() {
     load_time_zone("America/Los_Angeles", &lax);
     std::chrono::system_clock::time_point tp;
     
-    const bool ok = cctz::parse("%Y-%m-%d %H:%M:%S%p", civil_string, lax, &tp);
+    const bool ok = cctz::parse("%Y-%m-%d %H:%M:%S", civil_string, lax, &tp);
     
     if (!ok) return -1;
 

--- a/src/examples.cpp
+++ b/src/examples.cpp
@@ -5,6 +5,14 @@
 #include "civil_time.h"
 #include "time_zone.h"
 
+#if !defined(__MINGW32__) && !defined(__MINGW64__)
+#define RCPPCCTZ_TIME "%T"
+#define RCPPCCTZ_DATE_TIME "%F %T"
+#else
+#define RCPPCCTZ_TIME "%H:%M:%S"
+#define RCPPCCTZ_DATE_TIME "%Y-%m-%d %H:%M:%S"
+#endif
+
 // from examples/classic.cc
 // 
 std::string Format(const std::string& fmt, const std::tm& tm) {
@@ -19,11 +27,11 @@ void example0() {
 
     std::tm tm_utc;
     gmtime_r(&now, &tm_utc);
-    Rcpp::Rcout << Format("UTC: %Y-%m-%d %H:%M:%S\n", tm_utc);
+    Rcpp::Rcout << Format("UTC: " RCPPCCTZ_DATE_TIME "\n", tm_utc);
 
     std::tm tm_local;
     localtime_r(&now, &tm_local);
-    Rcpp::Rcout << Format("Local: %Y-%m-%d %H:%M:%S\n", tm_local);
+    Rcpp::Rcout << Format("Local: " RCPPCCTZ_DATE_TIME "\n", tm_local);
 }
 
 // from examples/hello.cc
@@ -36,11 +44,11 @@ Rcpp::CharacterVector helloMoon(bool verbose=false) {
 
     // Neil Armstrong first walks on the moon
     const auto tp = cctz::convert(cctz::civil_second(1969, 7, 20, 22, 56, 0), nyc);
-    const std::string s1 = cctz::format("%Y-%m-%d %H:%M:%S %z", tp, nyc);
+    const std::string s1 = cctz::format(RCPPCCTZ_DATE_TIME " %z", tp, nyc);
     if (verbose) Rcpp::Rcout << s1 << "\n";
 
     // That time in Sydney
-    const std::string s2 = cctz::format("%Y-%m-%d %H:%M:%S %z", tp, syd);
+    const std::string s2 = cctz::format(RCPPCCTZ_DATE_TIME " %z", tp, syd);
     if (verbose) Rcpp::Rcout << s2 << "\n";
     
     return Rcpp::CharacterVector::create(Rcpp::Named("New_York") = s1,
@@ -61,8 +69,10 @@ void example1() {
     cctz::time_zone nyc;
     load_time_zone("America/New_York", &nyc);
 
-    Rcpp::Rcout << cctz::format("Talk starts at %H:%M:%S %z (%Z)\n", tp, lax);
-    Rcpp::Rcout << cctz::format("Talk starts at %H:%M:%S %z (%Z)\n", tp, nyc);
+    Rcpp::Rcout << cctz::format("Talk starts at " RCPPCCTZ_TIME " %z (%Z)\n",
+        tp, lax);
+    Rcpp::Rcout << cctz::format("Talk starts at " RCPPCCTZ_TIME " %z (%Z)\n",
+        tp, nyc);
 
 }
 
@@ -95,8 +105,8 @@ void example3() {
     // First day of month, 6 months from now.
     const auto then = cctz::convert(cctz::civil_month(cs) + 6, lax);
     
-    Rcpp::Rcout << cctz::format("Now: %Y-%m-%d %H:%M:%S %z\n", now, lax);
-    Rcpp::Rcout << cctz::format("6mo: %Y-%m-%d %H:%M:%S %z\n", then, lax);
+    Rcpp::Rcout << cctz::format("Now: " RCPPCCTZ_DATE_TIME " %z\n", now, lax);
+    Rcpp::Rcout << cctz::format("6mo: " RCPPCCTZ_DATE_TIME " %z\n", then, lax);
 }
 
 
@@ -112,8 +122,8 @@ void example4() {
     load_time_zone("America/Los_Angeles", &lax);
     const auto now = std::chrono::system_clock::now();
     const auto day = FloorDay(now, lax);
-    Rcpp::Rcout << cctz::format("Now: %Y-%m-%d %H:%M:%S %z\n", now, lax);
-    Rcpp::Rcout << cctz::format("Day: %Y-%m-%d %H:%M:%S %z\n", day, lax);
+    Rcpp::Rcout << cctz::format("Now: " RCPPCCTZ_DATE_TIME " %z\n", now, lax);
+    Rcpp::Rcout << cctz::format("Day: " RCPPCCTZ_DATE_TIME " %z\n", day, lax);
 }
 
 

--- a/src/examples.cpp
+++ b/src/examples.cpp
@@ -19,11 +19,11 @@ void example0() {
 
     std::tm tm_utc;
     gmtime_r(&now, &tm_utc);
-    Rcpp::Rcout << Format("UTC: %F %T\n", tm_utc);
+    Rcpp::Rcout << Format("UTC: %Y-%m-%d %H:%M:%S\n", tm_utc);
 
     std::tm tm_local;
     localtime_r(&now, &tm_local);
-    Rcpp::Rcout << Format("Local: %F %T\n", tm_local);
+    Rcpp::Rcout << Format("Local: %Y-%m-%d %H:%M:%S\n", tm_local);
 }
 
 // from examples/hello.cc
@@ -36,11 +36,11 @@ Rcpp::CharacterVector helloMoon(bool verbose=false) {
 
     // Neil Armstrong first walks on the moon
     const auto tp = cctz::convert(cctz::civil_second(1969, 7, 20, 22, 56, 0), nyc);
-    const std::string s1 = cctz::format("%F %T %z", tp, nyc);
+    const std::string s1 = cctz::format("%Y-%m-%d %H:%M:%S %z", tp, nyc);
     if (verbose) Rcpp::Rcout << s1 << "\n";
 
     // That time in Sydney
-    const std::string s2 = cctz::format("%F %T %z", tp, syd);
+    const std::string s2 = cctz::format("%Y-%m-%d %H:%M:%S %z", tp, syd);
     if (verbose) Rcpp::Rcout << s2 << "\n";
     
     return Rcpp::CharacterVector::create(Rcpp::Named("New_York") = s1,
@@ -61,8 +61,8 @@ void example1() {
     cctz::time_zone nyc;
     load_time_zone("America/New_York", &nyc);
 
-    Rcpp::Rcout << cctz::format("Talk starts at %T %z (%Z)\n", tp, lax);
-    Rcpp::Rcout << cctz::format("Talk starts at %T %z (%Z)\n", tp, nyc);
+    Rcpp::Rcout << cctz::format("Talk starts at %H:%M:%S %z (%Z)\n", tp, lax);
+    Rcpp::Rcout << cctz::format("Talk starts at %H:%M:%S %z (%Z)\n", tp, nyc);
 
 }
 
@@ -95,8 +95,8 @@ void example3() {
     // First day of month, 6 months from now.
     const auto then = cctz::convert(cctz::civil_month(cs) + 6, lax);
     
-    Rcpp::Rcout << cctz::format("Now: %F %T %z\n", now, lax);
-    Rcpp::Rcout << cctz::format("6mo: %F %T %z\n", then, lax);
+    Rcpp::Rcout << cctz::format("Now: %Y-%m-%d %H:%M:%S %z\n", now, lax);
+    Rcpp::Rcout << cctz::format("6mo: %Y-%m-%d %H:%M:%S %z\n", then, lax);
 }
 
 
@@ -112,8 +112,8 @@ void example4() {
     load_time_zone("America/Los_Angeles", &lax);
     const auto now = std::chrono::system_clock::now();
     const auto day = FloorDay(now, lax);
-    Rcpp::Rcout << cctz::format("Now: %F %T %z\n", now, lax);
-    Rcpp::Rcout << cctz::format("Day: %F %T %z\n", day, lax);
+    Rcpp::Rcout << cctz::format("Now: %Y-%m-%d %H:%M:%S %z\n", now, lax);
+    Rcpp::Rcout << cctz::format("Day: %Y-%m-%d %H:%M:%S %z\n", day, lax);
 }
 
 
@@ -132,4 +132,3 @@ void exampleFormat() {
 
     Rcpp::Rcout << "15 digit precision on subsecond time: " << txt << std::endl;    
 }
-

--- a/src/examples.cpp
+++ b/src/examples.cpp
@@ -68,25 +68,14 @@ void example1() {
 
 // [[Rcpp::export]]
 int example2() {
-    // **************** TAKE THIS OUT ****************
-    const std::string civil_string = "2015-09-22 09:35:00AM";
-    // ***********************************************
-    
-    // **************** UNCOMMENT THIS ****************
-    //const std::string civil_string = "2015-09-22 09:35:00";
-    // ************************************************
+    const std::string civil_string = "2015-09-22 09:35:00";
 
     cctz::time_zone lax;
     load_time_zone("America/Los_Angeles", &lax);
     std::chrono::system_clock::time_point tp;
     
-    // **************** TAKE THIS OUT ****************
     const bool ok = cctz::parse("%Y-%m-%d %H:%M:%S%p", civil_string, lax, &tp);
-    // ***********************************************
     
-    // **************** UNCOMMENT THIS ****************
-    //const bool ok = cctz::parse("%Y-%m-%d %H:%M:%S%p", civil_string, lax, &tp);
-    // ************************************************
     if (!ok) return -1;
 
     const auto now = std::chrono::system_clock::now();

--- a/src/examples.cpp
+++ b/src/examples.cpp
@@ -68,12 +68,25 @@ void example1() {
 
 // [[Rcpp::export]]
 int example2() {
-    const std::string civil_string = "2015-09-22 09:35:00";
+    // **************** TAKE THIS OUT ****************
+    const std::string civil_string = "2015-09-22 09:35:00AM";
+    // ***********************************************
+    
+    // **************** UNCOMMENT THIS ****************
+    //const std::string civil_string = "2015-09-22 09:35:00";
+    // ************************************************
 
     cctz::time_zone lax;
     load_time_zone("America/Los_Angeles", &lax);
     std::chrono::system_clock::time_point tp;
-    const bool ok = cctz::parse("%Y-%m-%d %H:%M:%S", civil_string, lax, &tp);
+    
+    // **************** TAKE THIS OUT ****************
+    const bool ok = cctz::parse("%Y-%m-%d %H:%M:%S%p", civil_string, lax, &tp);
+    // ***********************************************
+    
+    // **************** UNCOMMENT THIS ****************
+    //const bool ok = cctz::parse("%Y-%m-%d %H:%M:%S%p", civil_string, lax, &tp);
+    // ************************************************
     if (!ok) return -1;
 
     const auto now = std::chrono::system_clock::now();

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -64,7 +64,7 @@ inline char* strptime(const char* s, const char* fmt, std::tm* tm)
 
 #else
 
-inline char* inline char* strptime(const char* s, const char* fmt, std::tm* tm)
+inline char* strptime(const char* s, const char* fmt, std::tm* tm)
 {
     ::strptime(s, fmt, tm);
 }

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -12,8 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#define __MINGW64__
-
 #if !defined(HAS_STRPTIME)
 # if !( defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__) )
 #  define HAS_STRPTIME 1  // assume everyone has strptime() except windows
@@ -72,7 +70,6 @@ inline char* inline char* strptime(const char* s, const char* fmt, std::tm* tm)
 }
 
 #endif
-#undef __MINGW64__
 
 namespace {
 std::tm ToTM(const time_zone::absolute_lookup& al) {

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -60,7 +60,9 @@ inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
 inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
     ::strptime(s, fmt, tm);
 }
+#endif
 }
+
 
 namespace cctz {
 namespace detail {

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -12,6 +12,8 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+#define __MINGW64__
+
 #if !defined(HAS_STRPTIME)
 # if !( defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__) )
 #  define HAS_STRPTIME 1  // assume everyone has strptime() except windows
@@ -28,18 +30,23 @@
 #include <ctime>
 #include <limits>
 #include <vector>
+
 #if !HAS_STRPTIME
 #include <iomanip>
 #include <sstream>
+#if defined(__MINGW32__) || defined(__MINGW64__)
 #include <get_time.h>
 #endif
+#endif
 
-namespace RcppCCTZ {
-
+namespace cctz {
+namespace detail {
 #if !HAS_STRPTIME
 
 // Build a strptime() using C++11's std::get_time().
-inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
+inline char* strptime(const char* s, const char* fmt, std::tm* tm)
+{
+  std::cout << "in my strptime." << std::endl;
   std::istringstream input(s);
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
@@ -56,16 +63,16 @@ inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
       return const_cast<char*>(s) + strlen(s);
   }
 }
+
 #else
-inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
+
+inline char* inline char* strptime(const char* s, const char* fmt, std::tm* tm)
+{
     ::strptime(s, fmt, tm);
 }
+
 #endif
-}
-
-
-namespace cctz {
-namespace detail {
+#undef __MINGW64__
 
 namespace {
 std::tm ToTM(const time_zone::absolute_lookup& al) {
@@ -516,7 +523,7 @@ const char* ParseSubSeconds(const char* dp,
 // Parses a string into a std::tm using strptime(3).
 const char* ParseTM(const char* dp, const char* fmt, std::tm* tm) {
   if (dp != nullptr) {
-    dp = RcppCCTZ::strptime(dp, fmt, tm);
+    dp = cctz::detail::strptime(dp, fmt, tm);
   }
   return dp;
 }

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -529,11 +529,7 @@ const char* ParseSubSeconds(const char* dp,
 // Parses a string into a std::tm using strptime(3).
 const char* ParseTM(const char* dp, const char* fmt, std::tm* tm) {
   if (dp != nullptr) {
-#if defined(__MINGW32__) || defined(__MINGW64__)
-    dp = nullptr;
-#else
     dp = RcppCCTZ::strptime(dp, fmt, tm);
-#endif    
   }
   return dp;
 }

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -12,19 +12,11 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-// **************** TAKE THIS OUT ****************
-#define __MINGW64__
-// ***********************************************
-
 #if !defined(HAS_STRPTIME)
 # if !( defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__) )
 #  define HAS_STRPTIME 1  // assume everyone has strptime() except windows
 # endif
 #endif
-
-// **************** TAKE THIS OUT ****************
-#undef __MINGW64__
-// ***********************************************
 
 #include "time_zone.h"
 #include "time_zone_if.h"
@@ -43,11 +35,9 @@
 #endif
 
 namespace RcppCCTZ {
-// **************** TAKE THIS OUT ****************
-#define __MINGW64__
-// ***********************************************
 
 #if !HAS_STRPTIME
+
 // Build a strptime() using C++11's std::get_time().
 inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
   std::istringstream input(s);
@@ -70,11 +60,6 @@ inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
 inline char* strptime(const char* s, const char* fmt, std::tm* tm) {
     ::strptime(s, fmt, tm);
 }
-#endif
-
-// **************** TAKE THIS OUT ****************
-#undef __MINGW64__
-// ***********************************************
 }
 
 namespace cctz {


### PR DESCRIPTION
This adds a backport of `std::get_time` (in the `std_backports` namespace) and shores up the `strptime()` implementation based on `std::get_time`.

Windows here we come!