### PR TITLE
Remove extraneous include

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -4,7 +4,6 @@
 
 #include "civil_time.h"
 #include "time_zone.h"
-#include "time_zone_if.h"
 #include <algorithm> //std::transform
 
 namespace sc = std::chrono; 	// shorthand


### PR DESCRIPTION
Nothing from it is used, plus it's an "internal" cctz file so dropping the include allows building against an unbundled system cctz.