### PR TITLE
C level function that returns the offset at a given time-point in a given timezone

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2019-09-07  Leonardo Silvestri <lsilvestri@ztsdb.org>
+
+	* DESCRIPTION (Version, Date): Release 0.2.7
+
+	* src/utilities.cpp: Added function _RcppCCTZ_getOffset to return
+	the offset at a time-point for a specific timezone
+	* src/RcppExports.cpp: Export the above function at C level
+
 2019-08-03  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.2.6

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppCCTZ
 Type: Package
 Title: 'Rcpp' Bindings for the 'CCTZ' Library
-Version: 0.2.6
-Date: 2019-08-03
+Version: 0.2.7
+Date: 2019-09-07
 Author: Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: 'Rcpp' Access to the 'CCTZ' timezone library is provided. 'CCTZ' is

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RcppCCTZ
 Type: Package
 Title: 'Rcpp' Bindings for the 'CCTZ' Library
-Version: 0.2.7
+Version: 0.2.6.1
 Date: 2019-09-07
 Author: Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,4 @@
+Changes in version 0.2.7
+  o Added function '_RcppCCTZ_getOffset' that returns the offset at a
+    speficied time-point for a specified timezone; this function is
+    only callable from C level

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,0 @@
-Changes in version 0.2.7
-  o Added function '_RcppCCTZ_getOffset' that returns the offset at a
-    speficied time-point for a specified timezone; this function is
-    only callable from C level

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,14 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/rcppcctz/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/rcppcctz/issues/#1}{##1}}
 
+\section{Changes in version 0.2.6.1 (2019-09-07)}{
+  \itemize{
+    \item Added function \code{_RcppCCTZ_getOffset} that returns the offset
+    at a speficied time-point for a specified timezone; this function is
+    only callable from C level. 
+  }
+}
+
 \section{Changes in version 0.2.6 (2019-08-03)}{
   \itemize{
     \item Synchronized with upstream CCTZ release 2.3 plus commits

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -163,6 +163,10 @@ BEGIN_RCPP
 END_RCPP
 }
 
+
+// export this function so it can be called at the C level by other packages:
+int _RcppCCTZ_getOffset(long long s, const char* tzstr);
+
 static const R_CallMethodDef CallEntries[] = {
     {"_RcppCCTZ_example0", (DL_FUNC) &_RcppCCTZ_example0, 0},
     {"_RcppCCTZ_helloMoon", (DL_FUNC) &_RcppCCTZ_helloMoon, 1},
@@ -178,10 +182,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_RcppCCTZ_formatDouble", (DL_FUNC) &_RcppCCTZ_formatDouble, 4},
     {"_RcppCCTZ_parseDouble", (DL_FUNC) &_RcppCCTZ_parseDouble, 3},
     {"_RcppCCTZ_now", (DL_FUNC) &_RcppCCTZ_now, 0},
+    {"_RcppCCTZ_getOffset", (DL_FUNC) &_RcppCCTZ_getOffset, 0},
     {NULL, NULL, 0}
 };
 
 RcppExport void R_init_RcppCCTZ(DllInfo *dll) {
+    R_RegisterCCallable("RcppCCTZ", "_RcppCCTZ_getOffset", (DL_FUNC) &_RcppCCTZ_getOffset);
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -165,7 +165,7 @@ END_RCPP
 
 
 // export this function so it can be called at the C level by other packages:
-int _RcppCCTZ_getOffset(long long s, const char* tzstr);
+int _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_RcppCCTZ_example0", (DL_FUNC) &_RcppCCTZ_example0, 0},

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -329,10 +329,11 @@ void now() {
 }
 
 
+// return the offset at a given time-point for a given timezone
 template <typename D>
 using time_point = std::chrono::time_point<std::chrono::system_clock, D>;
 using seconds = std::chrono::duration<std::int_fast64_t>;
-int _RcppCCTZ_getOffset(long long s, const char* tzstr) {
+int _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr) {
     // reloading the time zone at each point is inefficient, probably
     // want to try to cache some of this:
     cctz::time_zone tz;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -327,3 +327,17 @@ void now() {
     auto nanos = sc::duration_cast<sc::nanoseconds>(now.time_since_epoch()).count();
     Rcpp::Rcout << nanos << std::endl;
 }
+
+
+template <typename D>
+using time_point = std::chrono::time_point<std::chrono::system_clock, D>;
+using seconds = std::chrono::duration<std::int_fast64_t>;
+int _RcppCCTZ_getOffset(long long s, const char* tzstr) {
+    // reloading the time zone at each point is inefficient, probably
+    // want to try to cache some of this:
+    cctz::time_zone tz;
+    load_time_zone(tzstr, &tz);
+    const auto tp = time_point<seconds>(seconds(s));
+    auto abs_lookup = tz.lookup(tp);
+    return abs_lookup.offset;
+}


### PR DESCRIPTION
For `nanotime`'s `period` type, we need access to the timezone data so that adding and subtracting a `period` is correctly handled. The operation look like this:

~~~ R
    nt <- nanotime("2018-05-01T00:00:00.000000000-04:00")
    p  <- as.period("4m")
    tz <- "America/New_York"
    expected <- nanotime("2018-01-01T00:00:00.000000000-05:00")
    checkIdentical(minus(nt, p, tz), expected)
~~~

In order to do this, we need a function to get the offset for a particular timezone at a given time-point, the function `getOffset`. 

This function is then registered as a C function using `R_RegisterCCallable` so that it can be called at C level by another package.

This is an ad-hoc change for `nanotime`, but it could make sense to add the set of functions exported in R (or one could wait until there's a specific request of course!).