### PR TITLE
added '_RcppCCTZ_convertToCivilSecond' and '_RcppCCTZ_convertToTimePo…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2019-11-15  Leonardo Silvestri <lsilvestri@ztsdb.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+
+	* src/utilities.cpp: Added functions _RcppCCTZ_convertToCivilSecond that
+          converts a time point to the number of seconds since epoch, and
+	  _RcppCCTZ_convertToTimePoint that converts a number of seconds
+          since epoch into a time point
+	* src/RcppExports.cpp: Export the above functions at C level
+
 2019-09-07  Leonardo Silvestri <lsilvestri@ztsdb.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppCCTZ
 Type: Package
 Title: 'Rcpp' Bindings for the 'CCTZ' Library
-Version: 0.2.6.1
-Date: 2019-09-07
+Version: 0.2.6.2
+Date: 2019-11-15
 Author: Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: 'Rcpp' Access to the 'CCTZ' timezone library is provided. 'CCTZ' is

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,16 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/rcppcctz/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/rcppcctz/issues/#1}{##1}}
 
+\section{Changes in version 0.2.6.2 (2019-11-15)}{
+  \itemize{
+    \item Added functions \code{_RcppCCTZ_convertToCivilSecond} that
+    converts a time point to the number of seconds since epoch, and
+    \code{_RcppCCTZ_convertToTimePoint} that converts a number of seconds
+    since epoch into a time point; these functions are only callable
+    from C level. 
+  }
+}
+
 \section{Changes in version 0.2.6.1 (2019-09-07)}{
   \itemize{
     \item Added function \code{_RcppCCTZ_getOffset} that returns the offset

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2,6 +2,8 @@
 // Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 #include <Rcpp.h>
+#include "cctz/time_zone.h"
+
 
 using namespace Rcpp;
 
@@ -164,8 +166,6 @@ END_RCPP
 }
 
 
-// export this function so it can be called at the C level by other packages:
-int _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_RcppCCTZ_example0", (DL_FUNC) &_RcppCCTZ_example0, 0},
@@ -182,12 +182,24 @@ static const R_CallMethodDef CallEntries[] = {
     {"_RcppCCTZ_formatDouble", (DL_FUNC) &_RcppCCTZ_formatDouble, 4},
     {"_RcppCCTZ_parseDouble", (DL_FUNC) &_RcppCCTZ_parseDouble, 3},
     {"_RcppCCTZ_now", (DL_FUNC) &_RcppCCTZ_now, 0},
-    {"_RcppCCTZ_getOffset", (DL_FUNC) &_RcppCCTZ_getOffset, 0},
     {NULL, NULL, 0}
 };
 
+
+// export these functions so they can be called at the C level by other packages:
+template <typename D>
+using time_point = std::chrono::time_point<std::chrono::system_clock, D>;
+using seconds    = std::chrono::duration<std::int_fast64_t>;
+
+int                 _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr);
+cctz::civil_second  _RcppCCTZ_convertToCivilSecond(const time_point<seconds>& tp, const char* tzstr);
+time_point<seconds> _RcppCCTZ_convertToTimePoint(const cctz::civil_second& cs, const char* tzstr);
+
+  
 RcppExport void R_init_RcppCCTZ(DllInfo *dll) {
     R_RegisterCCallable("RcppCCTZ", "_RcppCCTZ_getOffset", (DL_FUNC) &_RcppCCTZ_getOffset);
+    R_RegisterCCallable("RcppCCTZ", "_RcppCCTZ_convertToCivilSecond", (DL_FUNC) &_RcppCCTZ_convertToCivilSecond);
+    R_RegisterCCallable("RcppCCTZ", "_RcppCCTZ_convertToTimePoint", (DL_FUNC) &_RcppCCTZ_convertToTimePoint);
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
 }


### PR DESCRIPTION
These two functions are necessary for `nanotime` at the C level. They are two of the main functions that are in the `cctz` API.