### PR TITLE
small fix to make sure an exception is raised in '_RcppCCTZ_getOffset…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-03-08  Leonardo Silvestri <lsilvestri@ztsdb.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+
+	* src/utilities.cpp (_RcppCCTZ_convertToCivilSecond): Throw if
+	timezone not found
+
 2019-11-15  Leonardo Silvestri <lsilvestri@ztsdb.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version
@@ -29,7 +36,7 @@
         * inst/tinytest/test_format.R: Converted from RUnit
         * inst/tinytest/test_parse.R: Idem
         * inst/tinytest/test_tz.R: Idem
-	
+
 	* README.md (tinytest): Added dependency badge, add installation
 	paragraph, add continued testing post-installation via tinytest
 
@@ -39,7 +46,7 @@
 
 	* src/*: Synchronized with upstream CCTZ release 2.3
 	* inst/include/cctz/*: Idem
-	
+
 	* src/time_zone_format.cc: Carry std::get_time patch forward
 	* src/zone_info_source.cc: Carry forward no linking ZoneInfoSourceFactory
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RcppCCTZ
 Type: Package
 Title: 'Rcpp' Bindings for the 'CCTZ' Library
-Version: 0.2.6.2
+Version: 0.2.6.3
 Date: 2019-11-15
 Author: Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -337,7 +337,9 @@ using seconds = std::chrono::duration<std::int_fast64_t>;
 int _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr) {
     // timezone caching is done by cctz
     cctz::time_zone tz;
-    load_time_zone(tzstr, &tz);
+    if (!load_time_zone(tzstr, &tz)) {
+        throw std::range_error("Cannot retrieve timezone");
+    }
     const auto tp = time_point<seconds>(seconds(s));
     auto abs_lookup = tz.lookup(tp);
     return abs_lookup.offset;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -349,7 +349,7 @@ int _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr) {
 cctz::civil_second _RcppCCTZ_convertToCivilSecond(const time_point<seconds>& tp, const char* tzstr) {
     cctz::time_zone tz;
     if (!load_time_zone(tzstr, &tz)) {
-        throw std::range_error("Cannot retrieve timezone");
+        Rcpp::stop("Cannot retrieve timezone '%s'.", tzstr);
     }
     return tz.lookup(tp).cs;
 }


### PR DESCRIPTION
…' when the specified timezone is not found

Otherwise is just falls back silently on UTC and in `nanotime` the user cannot know if for example there was a typo in the timezone he supplied.