### PR TITLE
add convertToCivilSecond wrapper

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-08-18  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+
+	* inst/include/RcppCCTZ_API.h: Add convertToCivilSecond too
+	* src/RcppExports.cpp: Note that one part is 'manual'
+
 2020-08-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppCCTZ
 Type: Package
 Title: 'Rcpp' Bindings for the 'CCTZ' Library
-Version: 0.2.8.1
-Date: 2020-08-13
+Version: 0.2.8.2
+Date: 2020-08-18
 Author: Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: 'Rcpp' Access to the 'CCTZ' timezone library is provided. 'CCTZ' is

--- a/inst/include/RcppCCTZ_API.h
+++ b/inst/include/RcppCCTZ_API.h
@@ -23,14 +23,19 @@ extern "C" {
 
 inline int attribute_hidden RcppCCTZ_getOffset_nothrow(std::int_fast64_t s, const char* tzstr, int& offset) {
   typedef int GET_OFFSET_FUN(long long, const char*, int&);
-  static GET_OFFSET_FUN *getOffset = (GET_OFFSET_FUN *) R_GetCCallable("RcppCCTZ", "_RcppCCTZ_getOffset_nothrow" );
+  static GET_OFFSET_FUN *getOffset = (GET_OFFSET_FUN *) R_GetCCallable("RcppCCTZ", "_RcppCCTZ_getOffset_nothrow");
   return getOffset(s, tzstr, offset);
+}
+
+inline int attribute_hidden RcppCCTZ_convertToCivilSecond_nothrow(const cctz::time_point<cctz::seconds>& tp, const char* tzstr, cctz::civil_second& cs) {
+  typedef int CONVERT_TO_CIVILSECOND(const cctz::time_point<cctz::seconds>&, const char*, cctz::civil_second&);
+  static CONVERT_TO_CIVILSECOND *convertToCivilSecond = (CONVERT_TO_CIVILSECOND*) R_GetCCallable("RcppCCTZ", "_RcppCCTZ_convertToCivilSecond_nothrow");
+  return convertToCivilSecond(tp, tzstr, cs);
 }
 
 inline int attribute_hidden RcppCCTZ_convertToTimePoint_nothrow(const cctz::civil_second& cs, const char* tzstr, cctz::time_point<cctz::seconds>& tp) {
   typedef int CONVERT_TO_TIMEPOINT(const cctz::civil_second&, const char*, cctz::time_point<cctz::seconds>&);
-  static CONVERT_TO_TIMEPOINT *convertToTimePoint =
-    (CONVERT_TO_TIMEPOINT*)  R_GetCCallable("RcppCCTZ", "_RcppCCTZ_convertToTimePoint_nothrow" );
+  static CONVERT_TO_TIMEPOINT *convertToTimePoint = (CONVERT_TO_TIMEPOINT*) R_GetCCallable("RcppCCTZ", "_RcppCCTZ_convertToTimePoint_nothrow");
   return convertToTimePoint(cs, tzstr, tp);
 }
 
@@ -43,8 +48,11 @@ namespace RcppCCTZ {
     return RcppCCTZ_getOffset_nothrow(s, tzstr, offset);
   }
 
-  inline int convertToTimePoint(const cctz::civil_second& cs, const char* tzstr,
-                                cctz::time_point<cctz::seconds>& tp) {
+  inline int convertToCivilSecond(const cctz::time_point<cctz::seconds>& tp, const char* tzstr, cctz::civil_second& cs) {
+    return RcppCCTZ_convertToCivilSecond_nothrow(tp, tzstr, cs);
+  }
+
+  inline int convertToTimePoint(const cctz::civil_second& cs, const char* tzstr, cctz::time_point<cctz::seconds>& tp) {
     return RcppCCTZ_convertToTimePoint_nothrow(cs, tzstr, tp);
   }
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -191,13 +191,13 @@ template <typename D>
 using time_point = std::chrono::time_point<std::chrono::system_clock, D>;
 using seconds    = std::chrono::duration<std::int_fast64_t>;
 
-int                 _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr);
-cctz::civil_second  _RcppCCTZ_convertToCivilSecond(const time_point<seconds>& tp, const char* tzstr);
-time_point<seconds> _RcppCCTZ_convertToTimePoint(const cctz::civil_second& cs, const char* tzstr);
+int                             _RcppCCTZ_getOffset(std::int_fast64_t s, const char* tzstr);
+cctz::civil_second              _RcppCCTZ_convertToCivilSecond(const cctz::time_point<cctz::seconds>& tp, const char* tzstr);
+cctz::time_point<cctz::seconds> _RcppCCTZ_convertToTimePoint(const cctz::civil_second& cs, const char* tzstr);
 
 int _RcppCCTZ_getOffset_nothrow(std::int_fast64_t s, const char* tzstr, int& offset);
-int _RcppCCTZ_convertToCivilSecond_nothrow(const time_point<seconds>& tp, const char* tzstr, cctz::civil_second& cs);
-int _RcppCCTZ_convertToTimePoint_nothrow(const cctz::civil_second& cs, const char* tzstr, time_point<seconds>& tp);
+int _RcppCCTZ_convertToCivilSecond_nothrow(const cctz::time_point<cctz::seconds>& tp, const char* tzstr, cctz::civil_second& cs);
+int _RcppCCTZ_convertToTimePoint_nothrow(const cctz::civil_second& cs, const char* tzstr, cctz::time_point<cctz::seconds>& tp);
 
 RcppExport void R_init_RcppCCTZ(DllInfo *dll) {
     R_RegisterCCallable("RcppCCTZ", "_RcppCCTZ_getOffset", (DL_FUNC) &_RcppCCTZ_getOffset);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -185,6 +185,10 @@ static const R_CallMethodDef CallEntries[] = {
     {NULL, NULL, 0}
 };
 
+// -- what follows below is hand-edited :-/ and may need to be recovered if compileAttributes()
+//    regenerates this file -- an obviously unsatisfactory solution but we got into some deadlocks
+//    between cctz symbols, what Rcpp::compileAttributes() generates (even with a RcppCCTZ_types.h
+//    header) and the need for clean import header.
 
 // export these functions so they can be called at the C level by other packages:
 template <typename D>

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -382,7 +382,7 @@ int _RcppCCTZ_getOffset_nothrow(std::int_fast64_t s, const char* tzstr, int& off
 }
 
 
-int _RcppCCTZ_convertToCivilSecond_nothrow(const time_point<seconds>& tp, const char* tzstr, cctz::civil_second& cs) {
+int _RcppCCTZ_convertToCivilSecond_nothrow(const cctz::time_point<cctz::seconds>& tp, const char* tzstr, cctz::civil_second& cs) {
     cctz::time_zone tz;
     if (!load_time_zone(tzstr, &tz)) {
         return -1;
@@ -392,7 +392,7 @@ int _RcppCCTZ_convertToCivilSecond_nothrow(const time_point<seconds>& tp, const 
 }
 
 
-int _RcppCCTZ_convertToTimePoint_nothrow(const cctz::civil_second& cs, const char* tzstr, time_point<seconds>& tp) {
+int _RcppCCTZ_convertToTimePoint_nothrow(const cctz::civil_second& cs, const char* tzstr, cctz::time_point<cctz::seconds>& tp) {
     cctz::time_zone tz;
     if (!load_time_zone(tzstr, &tz)) {
         return -1;


### PR DESCRIPTION
This adds the third function, and rearranges a little bit of whitespace