### PR TITLE
qualify format call in examples.cpp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2023-06-01  Michael Quinn <msquinn@google.com
+2023-06-01  Michael Quinn  <msquinn@google.com>
 
 	* src/examples.cpp: Qualify call to cctz::format()
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-06-01  Michael Quinn <msquinn@google.com
+
+	* src/examples.cpp: Qualify call to cctz::format()
+
 2023-04-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/src/examples.cpp
+++ b/src/examples.cpp
@@ -128,7 +128,7 @@ void exampleFormat() {
     tp += std::chrono::milliseconds(6) + std::chrono::microseconds(7) +
         std::chrono::nanoseconds(8);
 
-    std::string txt = format("%H:%M:%E15S", tp, tz);
+    std::string txt = cctz::format("%H:%M:%E15S", tp, tz);
 
     Rcpp::Rcout << "15 digit precision on subsecond time: " << txt << std::endl;    
 }


### PR DESCRIPTION
Fixes calls to unqualified `format` to avoid clashing with C++20 `std::format`.

Calls to the unqualified `format` function may now clash with the standard library `format` function due to argument-dependent lookup.