### PR TITLE
Update src/Makevars{,.win} to explicitly list files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-12-29  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/Makevars: Explicitly list source files allowing non-Windows
+	builds to skip one Windows files
+	* src/Makevars.win: Explicitly list source files including an
+	additional file used only on Windows
+
 2025-12-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,26 @@
 
-PKG_CXXFLAGS = -I../inst/include
+PKG_CXXFLAGS = -I. -I../inst/include
+
+## This excludes file 'time_zone_name_win.cc' included on Windows
+CCTZ_SOURCES = \
+   civil_time_detail.cc \
+   time_zone_fixed.cc \
+   time_zone_format.cc \
+   time_zone_if.cc \
+   time_zone_impl.cc \
+   time_zone_info.cc \
+   time_zone_libc.cc \
+   time_zone_lookup.cc \
+   time_zone_posix.cc \
+   zone_info_source.cc
+
+CCTZ_OBJECTS = $(CCTZ_SOURCES:.cc=.o)
+
+PKG_SOURCES = \
+   examples.cpp \
+   RcppExports.cpp \
+   utilities.cpp
+
+PKG_OBJECTS = $(PKG_SOURECES:.cpp=.o)
+
+$(SHLIB): $(CCTZ_OBJECTS) $(PKG_OBJECTS)

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,0 @@
-
-PKG_CXXFLAGS = -I../inst/include -D_POSIX_THREAD_SAFE_FUNCTIONS

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,27 @@
 
-PKG_CXXFLAGS = -I../inst/include
+PKG_CXXFLAGS = -I../inst/include -D_POSIX_THREAD_SAFE_FUNCTIONS
+
+## This includes file 'time_zone_name_win.cc' excluded outside of Windows
+CCTZ_SOURCES = \
+   civil_time_detail.cc \
+   time_zone_fixed.cc \
+   time_zone_format.cc \
+   time_zone_if.cc \
+   time_zone_impl.cc \
+   time_zone_info.cc \
+   time_zone_libc.cc \
+   time_zone_lookup.cc \
+   time_zone_name_win.cc \
+   time_zone_posix.cc \
+   zone_info_source.cc
+
+CCTZ_OBJECTS = $(CCTZ_SOURCES:.cc=.o)
+
+PKG_SOURCES = \
+   examples.cpp \
+   RcppExports.cpp \
+   utilities.cpp
+
+PKG_OBJECTS = $(PKG_SOURECES:.cpp=.o)
+
+$(SHLIB): $(CCTZ_OBJECTS) $(PKG_OBJECTS)


### PR DESCRIPTION
This allows us to accommodate the 'use on Windows only' file `time_zone_name_win.cc` which upstream manages by conditional inclusion via `cmake`.